### PR TITLE
fix(management): guard against IndexOutOfRangeException for K8SNS/K8SCluster alias parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.4
+
+## Bug Fixes
+- fix(management): `K8SNS` Management Add job no longer throws `IndexOutOfRangeException` when alias does not contain the expected `/` delimiter.
+- fix(management): `K8SNS` and `K8SCluster` Management Remove jobs no longer throw `IndexOutOfRangeException` when alias does not contain the expected `/` delimiter.
+
 # 1.1.3
 
 ## Bug Fixes

--- a/kubernetes-orchestrator-extension/Jobs/Management.cs
+++ b/kubernetes-orchestrator-extension/Jobs/Management.cs
@@ -548,6 +548,14 @@ public class Management : JobBase, IManagementJobExtension
                 jobCertObj.Alias = config.JobCertificate.Alias;
                 // Split alias by / and get second to last element KubeSecretType
                 var splitAlias = jobCertObj.Alias.Split("/");
+                if (splitAlias.Length < 2)
+                {
+                    var invalidAliasErrMsg =
+                        "Invalid alias format for K8SNS store type. Alias pattern: `<secret_type>/<secret_name>` where `secret_type` is one of 'opaque' or 'tls' and `secret_name` is the name of the secret.";
+                    Logger.LogError(invalidAliasErrMsg);
+                    Logger.LogInformation("End MANAGEMENT job " + config.JobId + " " + invalidAliasErrMsg + " Failed!");
+                    return FailJob(invalidAliasErrMsg, config.JobHistoryId);
+                }
                 KubeSecretType = splitAlias[^2];
                 KubeSecretName = splitAlias[^1];
                 Logger.LogDebug("Handling managment add job for K8SNS secret type '" + KubeSecretType + "(" + jobCertObj.Alias + ")'...");
@@ -656,6 +664,12 @@ public class Management : JobBase, IManagementJobExtension
             var splitAlias = certAlias.Split("/");
             if (Capability.Contains("K8SNS"))
             {
+                if (splitAlias.Length < 2)
+                {
+                    var errMsg = $"Invalid alias format for K8SNS store type. Expected pattern: 'secrets/<tls|opaque>/<secret_name>' but got '{certAlias}'";
+                    Logger.LogError(errMsg);
+                    return FailJob(errMsg, config.JobHistoryId);
+                }
                 // Split alias by / and get second to last element KubeSecretType
                 KubeSecretType = splitAlias[^2];
                 KubeSecretName = splitAlias[^1];
@@ -666,6 +680,12 @@ public class Management : JobBase, IManagementJobExtension
             }
             else if (Capability.Contains("K8SCluster"))
             {
+                if (splitAlias.Length < 3)
+                {
+                    var errMsg = $"Invalid alias format for K8SCluster store type. Expected pattern: '<namespace>/secrets/<tls|opaque>/<secret_name>' but got '{certAlias}'";
+                    Logger.LogError(errMsg);
+                    return FailJob(errMsg, config.JobHistoryId);
+                }
                 KubeSecretType = splitAlias[^2];
                 KubeSecretName = splitAlias[^1];
                 KubeNamespace = splitAlias[0];


### PR DESCRIPTION
## Summary

- **Root cause**: `HandleCreateOrUpdate` (namespace case) and `HandleRemove` both called `splitAlias[^2]` without a bounds check. A bare alias like `testcert` (no `/` delimiter) produces a single-element array, causing `Index was outside the bounds of the array` at runtime.
- Added `Length < 2` guard in `HandleCreateOrUpdate` namespace case before `splitAlias[^2]`/`splitAlias[^1]`
- Added `Length < 2` guard in `HandleRemove` for K8SNS before `splitAlias[^2]`/`splitAlias[^1]`
- Added `Length < 3` guard in `HandleRemove` for K8SCluster before `splitAlias[^2]`/`splitAlias[^1]`/`splitAlias[0]`

All invalid-alias paths now return a `FailJob` with a message describing the expected format instead of crashing with an unhandled exception.

## Test plan

- [x] Management Add to K8SNS store with a correctly formatted alias (`opaque/secret-name`) succeeds
- [x] Management Add to K8SNS store with a bare alias (`testcert`) returns a clear failure message instead of throwing
- [x] Management Remove from K8SNS store with a bare alias returns a clear failure message instead of throwing
- [x] Management Remove from K8SCluster store with a bare alias returns a clear failure message instead of throwing