### PR TITLE
fix(inventory): sanitize URL cluster names in discovery location strings

### DIFF
--- a/kubernetes-orchestrator-extension.Tests/Unit/Handlers/HandlerNoNetworkTests.cs
+++ b/kubernetes-orchestrator-extension.Tests/Unit/Handlers/HandlerNoNetworkTests.cs
@@ -263,4 +263,69 @@ public class HandlerNoNetworkTests
     }
 
     #endregion
+
+    #region SanitizeClusterName — B-035 regression guard
+
+    // When a store is configured with username/password auth (no kubeconfig), GetClusterName()
+    // falls back to GetHost(), which returns the raw API server URL such as "https://10.43.0.1/".
+    // Embedding that URL as the first segment of a location string (clusterName/namespace/secrets/name)
+    // produces paths like "https://10.43.0.1//cert-manager/secrets/lab-ca" that break parsing in
+    // ClusterSecretHandler.ProcessSecretEntry (parts[1] becomes "" instead of the namespace).
+    // SanitizeClusterName must strip the URL down to just the host component.
+
+    [Theory]
+    [InlineData("https://10.43.0.1/", "10.43.0.1")]
+    [InlineData("https://10.43.0.1:6443/", "10.43.0.1")]
+    [InlineData("https://k8s.example.com/", "k8s.example.com")]
+    [InlineData("http://127.0.0.1:8080", "127.0.0.1")]
+    public void SanitizeClusterName_AbsoluteUri_ReturnsHostOnly(string input, string expected)
+    {
+        var result = KubeCertificateManagerClient.SanitizeClusterName(input);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("local")]
+    [InlineData("my-cluster")]
+    [InlineData("kf-integrations")]
+    public void SanitizeClusterName_PlainName_ReturnedUnchanged(string input)
+    {
+        var result = KubeCertificateManagerClient.SanitizeClusterName(input);
+        Assert.Equal(input, result);
+    }
+
+    [Fact]
+    public void SanitizeClusterName_Null_ReturnsNull()
+    {
+        var result = KubeCertificateManagerClient.SanitizeClusterName(null);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void SanitizeClusterName_EmptyString_ReturnsEmptyString()
+    {
+        var result = KubeCertificateManagerClient.SanitizeClusterName(string.Empty);
+        Assert.Equal(string.Empty, result);
+    }
+
+    [Fact]
+    public void SanitizeClusterName_UrlAsClusterName_ProducesValidLocationPath()
+    {
+        // Regression test: location strings built with a raw URL as clusterName produced
+        // paths that ClusterSecretHandler.ProcessSecretEntry could not parse.
+        // After sanitization, parts[1] (the namespace) must equal "cert-manager", not "".
+        var rawUrl = "https://10.43.0.1/";
+        var namespaceName = "cert-manager";
+        var secretName = "lab-root-ca-secret";
+
+        var sanitized = KubeCertificateManagerClient.SanitizeClusterName(rawUrl);
+        var location = $"{sanitized}/{namespaceName}/secrets/{secretName}";
+        var parts = location.Split('/');
+
+        Assert.True(parts.Length >= 4, "Location must have at least 4 segments for ProcessSecretEntry to parse");
+        Assert.Equal("cert-manager", parts[1]);
+        Assert.Equal("lab-root-ca-secret", parts[^1]);
+    }
+
+    #endregion
 }

--- a/kubernetes-orchestrator-extension/Clients/KubeClient.cs
+++ b/kubernetes-orchestrator-extension/Clients/KubeClient.cs
@@ -100,6 +100,26 @@ public class KubeCertificateManagerClient
     private IKubernetes Client { get; set; }
 
     /// <summary>
+    /// Sanitizes a cluster name that may be a raw API server URL (e.g. "https://10.43.0.1/")
+    /// so that it is safe to embed as a path segment in discovery location strings.
+    /// When the value is an absolute URI (username/password auth — no kubeconfig), only the
+    /// <see cref="Uri.Host"/> component is kept (e.g. "https://10.43.0.1/" → "10.43.0.1").
+    /// Non-URI values (normal kubeconfig cluster names) are returned unchanged.
+    /// </summary>
+    /// <param name="clusterName">Raw value from <see cref="GetClusterName"/> or <see cref="GetHost"/>.</param>
+    /// <returns>A slash-free identifier suitable for use as the first segment of a location string.</returns>
+    public static string SanitizeClusterName(string clusterName)
+    {
+        if (string.IsNullOrEmpty(clusterName))
+            return clusterName;
+
+        if (Uri.TryCreate(clusterName, UriKind.Absolute, out var uri))
+            return uri.Host;
+
+        return clusterName;
+    }
+
+    /// <summary>
     /// Gets the name of the Kubernetes cluster from the configuration.
     /// Falls back to the host URL if the cluster name cannot be determined.
     /// </summary>
@@ -476,7 +496,7 @@ public class KubeCertificateManagerClient
         _logger.LogTrace("csr.Items.Count: {Count}", csr.Items.Count);
 
         _logger.LogTrace("Entering foreach loop to add certificate locations to list.");
-        var clusterName = GetClusterName();
+        var clusterName = SanitizeClusterName(GetClusterName() ?? GetHost());
         foreach (var cr in csr)
         {
             _logger.LogTrace("cr.Metadata.Name: {Name}", cr.Metadata.Name);
@@ -641,7 +661,7 @@ public class KubeCertificateManagerClient
         _logger.LogTrace("Parameters - AllowedKeys: [{Keys}], SecType: {SecType}, Namespace: {Ns}",
             string.Join(", ", allowedKeys ?? Array.Empty<string>()), secType, ns);
         var locations = new List<string>();
-        var clusterName = GetClusterName() ?? GetHost();
+        var clusterName = SanitizeClusterName(GetClusterName() ?? GetHost());
         _logger.LogTrace("ClusterName: {ClusterName}", clusterName);
 
         // Cluster-level discovery shortcut

--- a/kubernetes-orchestrator-extension/Jobs/JobBase.cs
+++ b/kubernetes-orchestrator-extension/Jobs/JobBase.cs
@@ -485,7 +485,7 @@ public abstract class JobBase
                 Logger.LogDebug("Kubernetes namespace resource type");
                 KubeSecretType = SecretTypes.Namespace;
                 Logger.MethodExit(MsLogLevel.Debug);
-                return $"{KubeClient.GetClusterName()}/namespace/{KubeNamespace}";
+                return $"{KubeCertificateManagerClient.SanitizeClusterName(KubeClient.GetClusterName())}/namespace/{KubeNamespace}";
             }
 
             if (SecretTypes.IsClusterType(secretType))
@@ -498,7 +498,7 @@ public abstract class JobBase
 
             secretType = NormalizeSecretTypeForPath(secretType);
 
-            var storePath = $"{KubeClient.GetClusterName()}/{KubeNamespace}/{secretType}/{KubeSecretName}";
+            var storePath = $"{KubeCertificateManagerClient.SanitizeClusterName(KubeClient.GetClusterName())}/{KubeNamespace}/{secretType}/{KubeSecretName}";
             Logger.LogDebug("Returning storePath: {StorePath}", storePath);
             Logger.MethodExit(MsLogLevel.Debug);
             return storePath;


### PR DESCRIPTION
## Problem

When a `K8SCluster` or `K8SNS` store is configured with username/password authentication (no kubeconfig), `GetClusterName()` falls back to `GetHost()`, which returns the raw Kubernetes API server URL — for example `https://10.43.0.1/`.

That raw URL was being embedded directly as the first path segment of every discovery location string:

```
https://10.43.0.1//cert-manager/secrets/lab-root-ca-secret
```

`ClusterSecretHandler.ProcessSecretEntry` then splits that string on `/` and reads `parts[1]` as the namespace. Because the URL contains `//` after the scheme, `parts[1]` resolves to `""` (empty string between `https:` and the host), not the actual namespace. Every subsequent `ReadNamespacedSecret("", ...)` call fails with not-found, so the entire inventory returns 0 entries even though the cluster has valid secrets.

The same defect affects `DiscoverCertificates` (K8SCert) and the store-path strings returned by `JobBase.GetStorePath` for non-cluster store types.

Fixes #87.

## Root cause

`KubeCertificateManagerClient.GetClusterName()` is documented to fall back to `GetHost()` when no kubeconfig is present. `GetHost()` returns `Client.BaseUri.ToString()` — the full API server URL including scheme and trailing slash. Callers that embed this value in slash-delimited path strings cannot safely parse it back out.

## Fix

Add a static `SanitizeClusterName(string)` helper to `KubeCertificateManagerClient`:

- If the value is an absolute URI (scheme present), return `Uri.Host` only — e.g. `https://10.43.0.1/` → `10.43.0.1`.
- If the value is a plain kubeconfig cluster name (e.g. `local`, `kf-integrations`), return it unchanged.
- Handles null/empty passthrough.

Apply the sanitization at the entry points where `clusterName` is first resolved:
- `DiscoverSecrets()` — covers `AddNamespaceLocation`, `DiscoverSecretsInNamespace`, and `ProcessSecret` downstream
- `DiscoverCertificates()` — K8SCert CSR location strings
- `JobBase.GetStorePath()` — namespace and per-secret store path strings

## Tests

Added a `SanitizeClusterName` regression block to `HandlerNoNetworkTests.cs`:

- Theory: absolute URIs (http/https, with/without port) are reduced to host-only
- Theory: plain cluster names are returned unchanged
- Null and empty string passthrough
- End-to-end location path parsing: location built with a URL `clusterName` → `Split('/')` → `parts[1]` equals the namespace, not `""`

## Affected store types

| Store type | Affected before fix | Notes |
|---|---|---|
| `K8SCluster` | Yes — 0 inventory entries with u/p auth | Primary reported symptom |
| `K8SNS` | Yes — same path parsing logic | Namespace-level discovery |
| `K8SCert` | Yes — CSR locations malformed | Cosmetic; no parse-back in current code |
| All others (`K8STLSSecr`, `K8SSecret`, `K8SJKS`, `K8SPKCS12`) | No | Pass namespace explicitly; don't use `ProcessSecretEntry` |